### PR TITLE
Update events with November 2025 conversatorio

### DIFF
--- a/lib/events.ts
+++ b/lib/events.ts
@@ -7,9 +7,13 @@ export type EventItem = {
 };
 
 export let events: EventItem[] = [
-  { title: "Conversatorio de Autonomía Digital", date: "15 JUN 2024", location: "Online", tag: "charla", link: "https://example.com/evento1" },
-  { title: "Taller de Hardware Libre", date: "22 JUN 2024", location: "Buenos Aires", tag: "taller", link: "https://example.com/evento2" },
-  { title: "Mesa Abierta de Gobernanza", date: "29 JUN 2024", location: "Online", tag: "debate", link: "https://example.com/evento3" },
+  {
+    title: "Conversatorio: IA, futuro del trabajo e imperialismo de datos en Latinoamérica",
+    date: "30 NOV 2025",
+    location: "Online (Discord)",
+    tag: "conversatorio",
+    link: "https://discord.gg/QrcXbnB2M?event=1443318360073965609",
+  },
 ];
 
 export function addEvent(item: EventItem) {


### PR DESCRIPTION
## Summary
- replace placeholder events with the November 30, 2025 online conversatorio and link to the Discord event

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69299cc9ccfc832abd66853c8e64c0ca)