### PR TITLE
Use VT323 as pixel font

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,6 +14,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="es">
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        <link
+          href="https://fonts.googleapis.com/css2?family=VT323&display=swap"
+          rel="stylesheet"
+        />
+      </head>
       <body
         className="font-mono bg-white text-coslat-blue antialiased flex flex-col md:flex-row min-h-screen"
       >

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
       },
       fontFamily: {
         title: ["Dahlia", "Georgia", "serif"],
-        pixel: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
+        pixel: ["VT323", "ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
         mono: ["ui-monospace", "SFMono-Regular", "Menlo", "monospace"],
         serif: ["Georgia", "serif"],
       },


### PR DESCRIPTION
## Summary
- add Google Fonts link for the VT323 typeface and include it globally
- point the Tailwind `font-pixel` family to use VT323 for pixel-styled elements

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6929aaa9a15c832a90c2ffbdfd7d43df)